### PR TITLE
nginx default site should pass headers

### DIFF
--- a/proxy/nginx/sites-enabled/default
+++ b/proxy/nginx/sites-enabled/default
@@ -29,6 +29,8 @@ server {
         proxy_connect_timeout 1;
         proxy_send_timeout 30;
         proxy_read_timeout 30;
+        proxy_pass_request_headers on;
+        proxy_pass_request_body on;
 
         proxy_pass http://$backend;
    }


### PR DESCRIPTION
For the purpose of module to module communication within xyz
